### PR TITLE
add symlinks to libraries to assist with loading

### DIFF
--- a/io.qt.qtwebengine.BaseApp.json
+++ b/io.qt.qtwebengine.BaseApp.json
@@ -22,7 +22,8 @@
             ],
             "post-install" : [
                 "cp -r /app/scratchdir/usr/* /app",
-                "rm -rf /app/scratchdir"
+                "rm -rf /app/scratchdir",
+                "ln -s /app/lib/*/*.so* /app/lib"
             ],
             "modules" : [
                 {


### PR DESCRIPTION
This adds *.so* symlinks into ld.so path and allows to use the BaseApp without LD_LIBRARY_PATH

Fixes #1 