### PR TITLE
Don't cleanup mkspecs

### DIFF
--- a/io.qt.qtwebengine.BaseApp.json
+++ b/io.qt.qtwebengine.BaseApp.json
@@ -9,8 +9,7 @@
             "name" : "qt5-qtwebengine",
             "buildsystem" : "qmake",
             "cleanup" : [
-                "/bin",
-                "/mkspecs"
+                "/bin"
             ],
             "make-install-args": ["INSTALL_ROOT=/app/scratchdir"],
             "config-opts" : [
@@ -23,7 +22,8 @@
             "post-install" : [
                 "cp -r /app/scratchdir/usr/* /app",
                 "rm -rf /app/scratchdir",
-                "ln -s /app/lib/*/*.so* /app/lib"
+                "ln -s /app/lib/*/*.so* /app/lib",
+                "mv /app/mkspecs /app/lib"
             ],
             "modules" : [
                 {


### PR DESCRIPTION
Just like we do it in: https://github.com/flathub/io.qt.qtwebkit.BaseApp

I added this originally to qtwebkit, to be able to compile a qmake based project.