### PR TITLE
make qmake-based apps compile

### DIFF
--- a/io.qt.qtwebengine.BaseApp.json
+++ b/io.qt.qtwebengine.BaseApp.json
@@ -23,7 +23,8 @@
             "post-install" : [
                 "cp -r /app/scratchdir/usr/* /app",
                 "rm -rf /app/scratchdir",
-                "ln -s /app/lib/*/*.so* /app/lib"
+                "ln -s /app/lib/*/*.so* /app/lib",
+                "find /app/lib/mkspecs/modules -type f -exec sed -i 's:$$QT_MODULE_LIB_BASE:/app/lib:' {} +"
             ],
             "modules" : [
                 {


### PR DESCRIPTION
Tested with enve (https://github.com/flathub/flathub/pull/1479).
```
g++: error: /usr/lib/x86_64-linux-gnu/libQt5WebEngineWidgets.so: No such file or directory
g++: error: /usr/lib/x86_64-linux-gnu/libQt5WebEngineCore.so: No such file or directory
make[2]: *** [Makefile:979: enve] Error 1
make[2]: Leaving directory '/run/build/enve/_flatpak_build/src/app'
make[1]: *** [Makefile:50: sub-app-make_first] Error 2
make[1]: Leaving directory '/run/build/enve/_flatpak_build/src'
make: *** [Makefile:47: sub-src-make_first] Error 2
Error: module enve: Child process exited with code 2
```