### PR TITLE
Set proper dir path for locales

### DIFF
--- a/io.qt.qtwebengine.BaseApp.json
+++ b/io.qt.qtwebengine.BaseApp.json
@@ -75,6 +75,10 @@
                 },
                 {
                     "type": "patch",
+                    "path": "patches/locales.patch"
+                },
+                {
+                    "type": "patch",
                     "path": "patches/resources.patch"
                 }
             ]

--- a/patches/locales.patch
+++ b/patches/locales.patch
@@ -1,0 +1,18 @@
+diff --git a/src/core/web_engine_library_info.cpp b/src/core/web_engine_library_info.cpp
+index 1c83164..b68c943 100644
+--- a/src/core/web_engine_library_info.cpp
++++ b/src/core/web_engine_library_info.cpp
+@@ -187,12 +187,7 @@ QString subProcessPath()
+ QString localesPath()
+ {
+     static bool initialized = false;
+-    static QString potentialLocalesPath =
+-#if defined(OS_MACOSX) && defined(QT_MAC_FRAMEWORK_BUILD)
+-            getResourcesPath(frameworkBundle()) % QLatin1String("/qtwebengine_locales");
+-#else
+-            QLibraryInfo::location(QLibraryInfo::TranslationsPath) % QDir::separator() % QLatin1String("qtwebengine_locales");
+-#endif
++    static QString potentialLocalesPath = "/app/translations/qtwebengine_locales";
+ 
+     if (!initialized) {
+         initialized = true;


### PR DESCRIPTION
Fixes errors like this:
```
Installed Qt WebEngine locales directory not found at location /usr/translations/qtwebengine_locales. Trying application directory...
Qt WebEngine locales directory not found at location /app/bin/qtwebengine_locales. Trying fallback directory... Translations MAY NOT not be correct.
```