### PR TITLE
Update to v5.15.5-lts and use f-e-d-c

### DIFF
--- a/flathub.json
+++ b/flathub.json
@@ -1,3 +1,4 @@
 {
+    "automerge-flathubbot-prs": false,
     "skip-appstream-check": true
 }

--- a/io.qt.qtwebengine.BaseApp.json
+++ b/io.qt.qtwebengine.BaseApp.json
@@ -26,8 +26,9 @@
             "config-opts": [
                 "--",
                 "-system-ffmpeg",
-                "-webengine-proprietary-codecs",
                 "-webengine-icu",
+                "-webengine-proprietary-codecs",
+                "-webengine-webrtc-pipewire",
                 "-webp"
             ],
             "post-install": [
@@ -86,7 +87,49 @@
                             ]
                         }
                     ]
+                },
+                {
+                    "name": "pipewire-0.2",
+                    "buildsystem": "meson",
+                    "config-opts": [
+                        "-D docs=false",
+                        "-D gstreamer=disabled",
+                        "-D man=false",
+                        "-D systemd=false"
+                    ],
+                    "sources": [
+                        {
+                            "type": "archive",
+                            "url": "https://github.com/PipeWire/pipewire/archive/0.2.7.tar.gz",
+                            "sha256": "bfaa0f6ae6c0791e2e0b59234d399753bf24f1b33dbf587682363a8463dd8df1"
+                        }
+                    ],
+                    "cleanup": [
+                        "/bin",
+                        "/etc",
+                        "/include",
+                        "/lib/gstreamer-1.0",
+                        "/lib/pipewire-0.2/libpipewire-module-audio-dsp.so",
+                        "/lib/pipewire-0.2/libpipewire-module-autolink.so",
+                        "/lib/pipewire-0.2/libpipewire-module-link-factory.so",
+                        "/lib/pipewire-0.2/libpipewire-module-mixer.so",
+                        "/lib/pipewire-0.2/libpipewire-module-portal.so",
+                        "/lib/pipewire-0.2/libpipewire-module-rtkit.so",
+                        "/lib/pipewire-0.2/libpipewire-module-spa-monitor.so",
+                        "/lib/pipewire-0.2/libpipewire-module-spa-node-factory.so",
+                        "/lib/pipewire-0.2/libpipewire-module-spa-node.so",
+                        "/lib/pipewire-0.2/libpipewire-module-suspend-on-idle.so",
+                        "/lib/spa/alsa",
+                        "/lib/spa/audiomixer",
+                        "/lib/spa/audiotestsrc",
+                        "/lib/spa/ffmpeg",
+                        "/lib/spa/test",
+                        "/lib/spa/v4l2",
+                        "/lib/spa/videotestsrc",
+                        "/lib/spa/volume"
+                    ]
                 }
+
             ],
             "sources": [
                 {

--- a/io.qt.qtwebengine.BaseApp.json
+++ b/io.qt.qtwebengine.BaseApp.json
@@ -3,11 +3,20 @@
     "branch": "5.15",
     "runtime": "org.kde.Platform",
     "sdk": "org.kde.Sdk",
+    "sdk-extensions": [
+        "org.freedesktop.Sdk.Extension.node14"
+    ],
     "runtime-version": "5.15",
     "modules": [
         {
             "name": "qt5-qtwebengine",
             "buildsystem": "qmake",
+            "build-options" : {
+                "append-path": "/usr/lib/sdk/node14/bin",
+                "env": [
+                  "npm_config_nodedir=/usr/lib/sdk/node14"
+                ]
+            },
             "cleanup": [
                 "/bin"
             ],
@@ -56,7 +65,12 @@
                         {
                             "type": "git",
                             "url": "https://kernel.googlesource.com/pub/scm/utils/pciutils/pciutils",
-                            "branch": "v3.6.4"
+                            "tag": "v3.6.4",
+                            "commit": "61ecc14a327de030336f1ff3fea9c7e7e55a90ca",
+                            "x-checker-data": {
+                                "type": "git",
+                                "tag-pattern": "^v([\\d.]+)$"
+                            }
                         },
                         {
                             "type": "shell",
@@ -69,9 +83,14 @@
             ],
             "sources": [
                 {
-                    "type": "archive",
-                    "url": "http://download.qt.io/archive/qt/5.15/5.15.2/submodules/qtwebengine-everywhere-src-5.15.2.tar.xz",
-                    "sha256": "c8afca0e43d84f7bd595436fbe4d13a5bbdb81ec5104d605085d07545b6f91e0"
+                    "type": "git",
+                    "url": "https://code.qt.io/qt/qtwebengine.git",
+                    "tag": "v5.15.2",
+                    "commit": "5537ff4437ea7a5f9ea140071343f88bf48deddc",
+                    "x-checker-data": {
+                        "type": "git",
+                        "tag-pattern": "^v(5\.15\.[\\d]+|5\.15\.[\\d]+-lts)?$"
+                    }
                 },
                 {
                     "type": "patch",

--- a/io.qt.qtwebengine.BaseApp.json
+++ b/io.qt.qtwebengine.BaseApp.json
@@ -45,7 +45,13 @@
                         {
                             "type": "archive",
                             "url": "https://www.python.org/ftp/python/2.7.18/Python-2.7.18.tar.xz",
-                            "sha256": "b62c0e7937551d0cc02b8fd5cb0f544f9405bafc9a54d3808ed4594812edef43"
+                            "sha256": "b62c0e7937551d0cc02b8fd5cb0f544f9405bafc9a54d3808ed4594812edef43",
+                            "x-checker-data": {
+                                "type": "anitya",
+                                "project-id": 13255,
+                                "stable-only": true,
+                                "url-template": "https://www.python.org/ftp/python/$version/Python-$version.tar.xz"
+                            }
                         }
                     ]
                 },
@@ -63,13 +69,14 @@
                     ],
                     "sources": [
                         {
-                            "type": "git",
-                            "url": "https://kernel.googlesource.com/pub/scm/utils/pciutils/pciutils",
-                            "tag": "v3.7.0",
-                            "commit": "864aecdea9c7db626856d8d452f6c784316a878c",
+                            "type": "archive",
+                            "url": "https://mj.ucw.cz/download/linux/pci/pciutils-3.7.0.tar.gz",
+                            "sha256": "08c27e01030d1fcc700d02bc2ea66c638f58a3d150e45e58852aa82ad4160d84",
                             "x-checker-data": {
-                                "type": "git",
-                                "tag-pattern": "^v([\\d.]+)$"
+                                "type": "anitya",
+                                "project-id": 2605,
+                                "stable-only": true,
+                                "url-template": "https://mj.ucw.cz/download/linux/pci/pciutils-$version.tar.gz"
                             }
                         },
                         {
@@ -84,12 +91,15 @@
             "sources": [
                 {
                     "type": "git",
-                    "url": "https://code.qt.io/qt/qtwebengine.git",
+                    "url": "https://invent.kde.org/qt/qt/qtwebengine.git",
                     "tag": "v5.15.5-lts",
                     "commit": "9711f64c5082040cb76f6da5ef4a16037dbda08f",
                     "x-checker-data": {
-                        "type": "git",
-                        "tag-pattern": "^v(5.15.[\\d]+|5.15.[\\d]+-lts)?$"
+                        "type": "json",
+                        "url": "https://invent.kde.org/api/v4/projects/qt%2Fqt%2Fqtwebengine/repository/tags",
+                        "tag-query": "first(.[].name | match( \"v5.15[\\\\d.]+-lts|v5.15[\\\\d.]+\" ) | .string)",
+                        "version-query": "$tag",
+                        "timestamp-query": ".[] | select(.name==$tag) | .commit.created_at"
                     }
                 },
                 {

--- a/io.qt.qtwebengine.BaseApp.json
+++ b/io.qt.qtwebengine.BaseApp.json
@@ -65,8 +65,8 @@
                         {
                             "type": "git",
                             "url": "https://kernel.googlesource.com/pub/scm/utils/pciutils/pciutils",
-                            "tag": "v3.6.4",
-                            "commit": "61ecc14a327de030336f1ff3fea9c7e7e55a90ca",
+                            "tag": "v3.7.0",
+                            "commit": "864aecdea9c7db626856d8d452f6c784316a878c",
                             "x-checker-data": {
                                 "type": "git",
                                 "tag-pattern": "^v([\\d.]+)$"
@@ -85,11 +85,11 @@
                 {
                     "type": "git",
                     "url": "https://code.qt.io/qt/qtwebengine.git",
-                    "tag": "v5.15.2",
-                    "commit": "5537ff4437ea7a5f9ea140071343f88bf48deddc",
+                    "tag": "v5.15.5-lts",
+                    "commit": "9711f64c5082040cb76f6da5ef4a16037dbda08f",
                     "x-checker-data": {
                         "type": "git",
-                        "tag-pattern": "^v(5\.15\.[\\d]+|5\.15\.[\\d]+-lts)?$"
+                        "tag-pattern": "^v(5.15.[\\d]+|5.15.[\\d]+-lts)?$"
                     }
                 },
                 {

--- a/io.qt.qtwebengine.BaseApp.metainfo.xml
+++ b/io.qt.qtwebengine.BaseApp.metainfo.xml
@@ -7,4 +7,7 @@
   <summary>Shared platform for applications that use Qt WebEngine</summary>
   <url type="homepage">https://qt.io</url>
   <project_group>KDE</project_group>
+  <releases>
+    <release version="5.15.5-lts" date="2021-06-21"/>
+  </releases>
 </component>

--- a/patches/locales.patch
+++ b/patches/locales.patch
@@ -1,18 +1,13 @@
 diff --git a/src/core/web_engine_library_info.cpp b/src/core/web_engine_library_info.cpp
-index 1c83164..b68c943 100644
+index 3a649227..56d31e46 100644
 --- a/src/core/web_engine_library_info.cpp
 +++ b/src/core/web_engine_library_info.cpp
-@@ -187,12 +187,7 @@ QString subProcessPath()
- QString localesPath()
- {
-     static bool initialized = false;
--    static QString potentialLocalesPath =
--#if defined(OS_MACOSX) && defined(QT_MAC_FRAMEWORK_BUILD)
--            getResourcesPath(frameworkBundle()) % QLatin1String("/qtwebengine_locales");
--#else
+@@ -205,7 +205,7 @@ QString localesPath()
+ #if defined(OS_MAC) && defined(QT_MAC_FRAMEWORK_BUILD)
+             getResourcesPath(frameworkBundle()) % QLatin1String("/qtwebengine_locales");
+ #else
 -            QLibraryInfo::location(QLibraryInfo::TranslationsPath) % QDir::separator() % QLatin1String("qtwebengine_locales");
--#endif
-+    static QString potentialLocalesPath = "/app/translations/qtwebengine_locales";
++            "/app/translations/qtwebengine_locales";
+ #endif
  
      if (!initialized) {
-         initialized = true;

--- a/patches/resources.patch
+++ b/patches/resources.patch
@@ -1,10 +1,10 @@
 diff --git a/src/core/web_engine_library_info.cpp b/src/core/web_engine_library_info.cpp
-index 1c831643..2b8e6e11 100644
+index 56d31e46..28db02f6 100644
 --- a/src/core/web_engine_library_info.cpp
 +++ b/src/core/web_engine_library_info.cpp
-@@ -264,7 +264,7 @@ QString resourcesDataPath()
- #if defined(OS_MACOSX) && defined(QT_MAC_FRAMEWORK_BUILD)
-             getResourcesPath(frameworkBundle());
+@@ -280,7 +280,7 @@ QString resourcesDataPath()
+ #elif defined(OS_MAC)
+             QLibraryInfo::location(QLibraryInfo::DataPath) % QLatin1String("/Resources");
  #else
 -            QLibraryInfo::location(QLibraryInfo::DataPath) % QLatin1String("/resources");
 +            QLatin1String("/app/resources");


### PR DESCRIPTION
* Build the latest 5.15 tagged release from code.qt.io and also bump pciutils to v3.7.0.  
* Add x-checker-data properties to qt5-qtwebengine and pciutils modules.
* Switch qt5-qtwebengine to git source. **update: and to KDE mirror to be able to use the JSON checker.**
* Add SDK extension org.freedesktop.Sdk.Extension.node14.
* ~~I haven't bothered adding the x-checker-data property to python2 as it's not distributed, and I prefer to not touch build dependencies on such a long build.~~ **update:** Also added python2 check now.
* The regex pattern for qt5-qtwebengine seems to match the 5.15.x tags correctly.
* First time updating with flatpak-external-data-checker (manually), later update PRs will ~~hopefully~~ be opened by flathubbot.
* ~~This was not tested as build time is too long.~~ **Update: It's working correctly with qutebrowser.**
* **update: Enabled PipeWire RTC support and the needed PipeWire 0.2 module (pre-Chromium 89 requirement). Wayland screen sharing is now possible with qutebrowser.**

Closes #14.
