### PR TITLE
Bump to 5.15.6

### DIFF
--- a/io.qt.qtwebengine.BaseApp.json
+++ b/io.qt.qtwebengine.BaseApp.json
@@ -141,7 +141,7 @@
                         "type": "json",
                         "url": "https://invent.kde.org/api/v4/projects/qt%2Fqt%2Fqtwebengine/repository/tags",
                         "tag-query": "first(.[].name | match( \"v5.15[\\\\d.]+-lts|v5.15[\\\\d.]+\" ) | .string)",
-                        "version-query": "$tag",
+                        "version-query": "$tag | sub(\"^v\"; \"\")",
                         "timestamp-query": ".[] | select(.name==$tag) | .commit.created_at"
                     }
                 },

--- a/io.qt.qtwebengine.BaseApp.json
+++ b/io.qt.qtwebengine.BaseApp.json
@@ -11,10 +11,10 @@
         {
             "name": "qt5-qtwebengine",
             "buildsystem": "qmake",
-            "build-options" : {
+            "build-options": {
                 "append-path": "/usr/lib/sdk/node14/bin",
                 "env": [
-                  "npm_config_nodedir=/usr/lib/sdk/node14"
+                    "npm_config_nodedir=/usr/lib/sdk/node14"
                 ]
             },
             "cleanup": [
@@ -129,14 +129,13 @@
                         "/lib/spa/volume"
                     ]
                 }
-
             ],
             "sources": [
                 {
                     "type": "git",
                     "url": "https://invent.kde.org/qt/qt/qtwebengine.git",
-                    "tag": "v5.15.5-lts",
-                    "commit": "9711f64c5082040cb76f6da5ef4a16037dbda08f",
+                    "tag": "v5.15.6-lts",
+                    "commit": "2acbba86362ac3a1c2d8c20390dc263875f8f09c",
                     "x-checker-data": {
                         "type": "json",
                         "url": "https://invent.kde.org/api/v4/projects/qt%2Fqt%2Fqtwebengine/repository/tags",

--- a/io.qt.qtwebengine.BaseApp.metainfo.xml
+++ b/io.qt.qtwebengine.BaseApp.metainfo.xml
@@ -8,6 +8,7 @@
   <url type="homepage">https://qt.io</url>
   <project_group>KDE</project_group>
   <releases>
+    <release version="5.15.6-lts" date="2021-08-24"/>
     <release version="5.15.5-lts" date="2021-06-21"/>
   </releases>
 </component>


### PR DESCRIPTION
Fix the `version-query` property of f-e-d-c, and bump qtwebkit by manually running f-e-d-c. Supersede #21 and should fix the build issue.