### PR TITLE
Update runtime to 5.15-21.08

### DIFF
--- a/io.qt.qtwebengine.BaseApp.json
+++ b/io.qt.qtwebengine.BaseApp.json
@@ -137,6 +137,7 @@
                     "tag": "v5.15.6-lts",
                     "commit": "2acbba86362ac3a1c2d8c20390dc263875f8f09c",
                     "x-checker-data": {
+                        "is-main-source": true,
                         "type": "json",
                         "url": "https://invent.kde.org/api/v4/projects/qt%2Fqt%2Fqtwebengine/repository/tags",
                         "tag-query": "first(.[].name | match( \"v5.15[\\\\d.]+-lts|v5.15[\\\\d.]+\" ) | .string)",

--- a/io.qt.qtwebengine.BaseApp.json
+++ b/io.qt.qtwebengine.BaseApp.json
@@ -1,12 +1,12 @@
 {
     "id": "io.qt.qtwebengine.BaseApp",
-    "branch": "5.15",
+    "branch": "5.15-21.08",
     "runtime": "org.kde.Platform",
     "sdk": "org.kde.Sdk",
     "sdk-extensions": [
         "org.freedesktop.Sdk.Extension.node14"
     ],
-    "runtime-version": "5.15",
+    "runtime-version": "5.15-21.08",
     "modules": [
         {
             "name": "qt5-qtwebengine",
@@ -151,6 +151,38 @@
                 {
                     "type": "patch",
                     "path": "patches/resources.patch"
+                },
+                {
+                    "type": "patch",
+                    "path": "patches/qt5-webengine-glibc-2.33.patch"
+                },
+                {
+                    "type": "patch",
+                    "path": "patches/chromium-harfbuzz-3.0.0.patch",
+                    "options": [
+                        "--directory=src/3rdparty/chromium"
+                    ]
+                },
+                {
+                    "type": "patch",
+                    "path": "patches/chromium-skia-harfbuzz-3.0.0.patch",
+                    "options": [
+                        "--directory=src/3rdparty/chromium/third_party/skia"
+                    ]
+                },
+                {
+                    "type": "patch",
+                    "path": "patches/chromium-fix-in-tree-libxml2-build-with-icu-68.patch",
+                    "options": [
+                        "--directory=src/3rdparty"
+                    ]
+                },
+                {
+                    "type": "patch",
+                    "path": "patches/chromium-disable-thin-archives.patch",
+                    "options": [
+                        "--directory=src/3rdparty"
+                    ]
                 }
             ]
         },

--- a/patches/chromium-disable-thin-archives.patch
+++ b/patches/chromium-disable-thin-archives.patch
@@ -1,0 +1,11 @@
+--- a/chromium/build/config/compiler/BUILD.gn	2021-10-06 14:14:23.931831253 +0300
++++ b/chromium/build/config/compiler/BUILD.gn	2021-10-06 14:14:33.208380239 +0300
+@@ -1803,7 +1803,7 @@
+   # have a "thin archive" mode (it does accept -T, but it means truncating
+   # archive names to 16 characters, which is not what we want).
+   if ((is_posix && !is_nacl && !is_apple) || is_fuchsia) {
+-    arflags = [ "-T" ]
++    arflags = []
+   } else if (is_win && use_lld) {
+     arflags = [ "/llvmlibthin" ]
+   }

--- a/patches/chromium-fix-in-tree-libxml2-build-with-icu-68.patch
+++ b/patches/chromium-fix-in-tree-libxml2-build-with-icu-68.patch
@@ -1,0 +1,76 @@
+From 77566acdae0163f3d7fc7295981471a7b63dff44 Mon Sep 17 00:00:00 2001
+From: tinywrkb <tinywrkb@gmail.com>
+Date: Sat, 2 Oct 2021 21:25:28 +0300
+Subject: [PATCH] fix in-tree libxml2 build with icu 68
+
+---
+ chromium/third_party/libxml/src/encoding.c    | 4 ++--
+ chromium/third_party/libxml/src/runtest.c     | 2 +-
+ chromium/third_party/libxml/src/testThreads.c | 2 +-
+ chromium/third_party/libxml/src/threads.c     | 6 +++---
+ 4 files changed, 7 insertions(+), 7 deletions(-)
+
+diff --git a/chromium/third_party/libxml/src/encoding.c b/chromium/third_party/libxml/src/encoding.c
+index c34aca44663..61180d51e6f 100644
+--- a/chromium/third_party/libxml/src/encoding.c
++++ b/chromium/third_party/libxml/src/encoding.c
+@@ -2004,7 +2004,7 @@ xmlEncOutputChunk(xmlCharEncodingHandler *handler, unsigned char *out,
+ #ifdef LIBXML_ICU_ENABLED
+     else if (handler->uconv_out != NULL) {
+         ret = xmlUconvWrapper(handler->uconv_out, 0, out, outlen, in, inlen,
+-                              TRUE);
++                              1);
+     }
+ #endif /* LIBXML_ICU_ENABLED */
+     else {
+diff --git a/chromium/third_party/libxml/src/runtest.c b/chromium/third_party/libxml/src/runtest.c
+index 0f178cb050a..da2d06b71cf 100644
+--- a/chromium/third_party/libxml/src/runtest.c
++++ b/chromium/third_party/libxml/src/runtest.c
+@@ -4078,7 +4078,7 @@ testThread(void)
+             }
+         }
+ 
+-        if (WaitForMultipleObjects(num_threads, tid, TRUE, INFINITE) ==
++        if (WaitForMultipleObjects(num_threads, tid, 1, INFINITE) ==
+             WAIT_FAILED) {
+             fprintf(stderr, "WaitForMultipleObjects failed\n");
+ 	    return(1);
+diff --git a/chromium/third_party/libxml/src/testThreads.c b/chromium/third_party/libxml/src/testThreads.c
+index bef6537744b..6c429b153ae 100644
+--- a/chromium/third_party/libxml/src/testThreads.c
++++ b/chromium/third_party/libxml/src/testThreads.c
+@@ -181,7 +181,7 @@ main(void)
+             }
+         }
+ 
+-        if (WaitForMultipleObjects (num_threads, tid, TRUE, INFINITE) == WAIT_FAILED)
++        if (WaitForMultipleObjects (num_threads, tid, 1, INFINITE) == WAIT_FAILED)
+             perror ("WaitForMultipleObjects failed");
+ 
+         for (i = 0; i < num_threads; i++)
+diff --git a/chromium/third_party/libxml/src/threads.c b/chromium/third_party/libxml/src/threads.c
+index 503d2bfbec0..611080b99f5 100644
+--- a/chromium/third_party/libxml/src/threads.c
++++ b/chromium/third_party/libxml/src/threads.c
+@@ -705,7 +705,7 @@ xmlGetGlobalState(void)
+         p->memory = tsd;
+ #if defined(LIBXML_STATIC) && !defined(LIBXML_STATIC_FOR_DLL)
+         DuplicateHandle(GetCurrentProcess(), GetCurrentThread(),
+-                        GetCurrentProcess(), &p->thread, 0, TRUE,
++                        GetCurrentProcess(), &p->thread, 0, 1,
+                         DUPLICATE_SAME_ACCESS);
+         TlsSetValue(globalkey, tsd);
+         _beginthread(xmlGlobalStateCleanupHelper, 0, p);
+@@ -1042,7 +1042,7 @@ DllMain(ATTRIBUTE_UNUSED HINSTANCE hinstDLL, DWORD fdwReason,
+             }
+             break;
+     }
+-    return TRUE;
++    return 1;
+ }
+ #endif
+ #define bottom_threads
+-- 
+2.33.0
+

--- a/patches/chromium-harfbuzz-3.0.0.patch
+++ b/patches/chromium-harfbuzz-3.0.0.patch
@@ -1,0 +1,21 @@
+# https://github.com/archlinux/svntogit-packages/blob/packages/qt5-webengine/trunk/chromium-harfbuzz-3.0.0.patch
+# https://github.com/chromium/chromium/commit/b289f6f3fcbc
+
+diff --git a/components/paint_preview/common/subset_font.cc b/components/paint_preview/common/subset_font.cc
+index 8ff0540d9a..20a7d37474 100644
+--- a/components/paint_preview/common/subset_font.cc
++++ b/components/paint_preview/common/subset_font.cc
+@@ -72,9 +72,11 @@ sk_sp<SkData> SubsetFont(SkTypeface* typeface, const GlyphUsage& usage) {
+   hb_set_t* glyphs =
+       hb_subset_input_glyph_set(input.get());  // Owned by |input|.
+   usage.ForEach(base::BindRepeating(&AddGlyphs, base::Unretained(glyphs)));
+-  hb_subset_input_set_retain_gids(input.get(), true);
++  hb_subset_input_set_flags(input.get(), HB_SUBSET_FLAGS_RETAIN_GIDS);
+ 
+-  HbScoped<hb_face_t> subset_face(hb_subset(face.get(), input.get()));
++  HbScoped<hb_face_t> subset_face(hb_subset_or_fail(face.get(), input.get()));
++  if (!subset_face)
++    return nullptr;
+   HbScoped<hb_blob_t> subset_blob(hb_face_reference_blob(subset_face.get()));
+   if (!subset_blob)
+     return nullptr;

--- a/patches/chromium-skia-harfbuzz-3.0.0.patch
+++ b/patches/chromium-skia-harfbuzz-3.0.0.patch
@@ -1,0 +1,101 @@
+# https://github.com/archlinux/svntogit-packages/blob/packages/qt5-webengine/trunk/skia-harfbuzz-3.0.0.patch
+# Minimal diff for harfbuzz 3.0.0 support; based on:
+# https://github.com/google/skia/commit/66684b17b382
+# https://github.com/google/skia/commit/51d83abcd24a
+
+diff --git a/gn/skia.gni b/gn/skia.gni
+index d98fdc19ee..199335d5c4 100644
+--- a/gn/skia.gni
++++ b/gn/skia.gni
+@@ -34,8 +34,6 @@ declare_args() {
+   skia_include_multiframe_procs = false
+   skia_lex = false
+   skia_libgifcodec_path = "third_party/externals/libgifcodec"
+-  skia_pdf_subset_harfbuzz =
+-      false  # TODO: set skia_pdf_subset_harfbuzz to skia_use_harfbuzz.
+   skia_qt_path = getenv("QT_PATH")
+   skia_skqp_global_error_tolerance = 0
+   skia_tools_require_resources = false
+@@ -99,6 +97,10 @@ declare_args() {
+   skia_use_libfuzzer_defaults = true
+ }
+ 
++declare_args() {
++  skia_pdf_subset_harfbuzz = skia_use_harfbuzz
++}
++
+ declare_args() {
+   skia_compile_sksl_tests = skia_compile_processors
+   skia_enable_fontmgr_android = skia_use_expat && skia_use_freetype
+diff --git a/src/pdf/SkPDFSubsetFont.cpp b/src/pdf/SkPDFSubsetFont.cpp
+index 81c37eef3a..2340a7937b 100644
+--- a/src/pdf/SkPDFSubsetFont.cpp
++++ b/src/pdf/SkPDFSubsetFont.cpp
+@@ -49,6 +49,37 @@ static sk_sp<SkData> to_data(HBBlob blob) {
+                                 blob.release());
+ }
+ 
++template<typename...> using void_t = void;
++template<typename T, typename = void>
++struct SkPDFHarfBuzzSubset {
++    // This is the HarfBuzz 3.0 interface.
++    // hb_subset_flags_t does not exist in 2.0. It isn't dependent on T, so inline the value of
++    // HB_SUBSET_FLAGS_RETAIN_GIDS until 2.0 is no longer supported.
++    static HBFace Make(T input, hb_face_t* face) {
++        // TODO: When possible, check if a font is 'tricky' with FT_IS_TRICKY.
++        // If it isn't known if a font is 'tricky', retain the hints.
++        hb_subset_input_set_flags(input, 2/*HB_SUBSET_FLAGS_RETAIN_GIDS*/);
++        return HBFace(hb_subset_or_fail(face, input));
++    }
++};
++template<typename T>
++struct SkPDFHarfBuzzSubset<T, void_t<
++    decltype(hb_subset_input_set_retain_gids(std::declval<T>(), std::declval<bool>())),
++    decltype(hb_subset_input_set_drop_hints(std::declval<T>(), std::declval<bool>())),
++    decltype(hb_subset(std::declval<hb_face_t*>(), std::declval<T>()))
++    >>
++{
++    // This is the HarfBuzz 2.0 (non-public) interface, used if it exists.
++    // This code should be removed as soon as all users are migrated to the newer API.
++    static HBFace Make(T input, hb_face_t* face) {
++        hb_subset_input_set_retain_gids(input, true);
++        // TODO: When possible, check if a font is 'tricky' with FT_IS_TRICKY.
++        // If it isn't known if a font is 'tricky', retain the hints.
++        hb_subset_input_set_drop_hints(input, false);
++        return HBFace(hb_subset(face, input));
++    }
++};
++
+ static sk_sp<SkData> subset_harfbuzz(sk_sp<SkData> fontData,
+                                      const SkPDFGlyphUse& glyphUsage,
+                                      int ttcIndex) {
+@@ -71,11 +102,10 @@ static sk_sp<SkData> subset_harfbuzz(sk_sp<SkData> fontData,
+     hb_set_t* glyphs = hb_subset_input_glyph_set(input.get());
+     glyphUsage.getSetValues([&glyphs](unsigned gid) { hb_set_add(glyphs, gid);});
+ 
+-    hb_subset_input_set_retain_gids(input.get(), true);
+-    // TODO: When possible, check if a font is 'tricky' with FT_IS_TRICKY.
+-    // If it isn't known if a font is 'tricky', retain the hints.
+-    hb_subset_input_set_drop_hints(input.get(), false);
+-    HBFace subset(hb_subset(face.get(), input.get()));
++    HBFace subset = SkPDFHarfBuzzSubset<hb_subset_input_t*>::Make(input.get(), face.get());
++    if (!subset) {
++        return nullptr;
++    }
+     HBBlob result(hb_face_reference_blob(subset.get()));
+     return to_data(std::move(result));
+ }
+diff --git a/third_party/harfbuzz/BUILD.gn b/third_party/harfbuzz/BUILD.gn
+index 173830de62..4156607ef9 100644
+--- a/third_party/harfbuzz/BUILD.gn
++++ b/third_party/harfbuzz/BUILD.gn
+@@ -14,6 +14,9 @@ if (skia_use_system_harfbuzz) {
+   system("harfbuzz") {
+     include_dirs = [ "/usr/include/harfbuzz" ]
+     libs = [ "harfbuzz" ]
++    if (skia_pdf_subset_harfbuzz) {
++      libs += [ "harfbuzz-subset" ]
++    }
+   }
+ } else {
+   third_party("harfbuzz") {

--- a/patches/qt5-webengine-glibc-2.33.patch
+++ b/patches/qt5-webengine-glibc-2.33.patch
@@ -1,0 +1,145 @@
+# https://github.com/archlinux/svntogit-packages/blob/packages/qt5-webengine/trunk/qt5-webengine-glibc-2.33.patch
+# Patch made by Kevin Kofler <Kevin@tigcc.ticalc.org>
+# https://bugzilla.redhat.com/show_bug.cgi?id=1904652
+
+diff -ur qtwebengine-everywhere-src-5.15.2/src/3rdparty/chromium/sandbox/linux/seccomp-bpf-helpers/baseline_policy.cc qtwebengine-everywhere-src-5.15.2-#1904652/src/3rdparty/chromium/sandbox/linux/seccomp-bpf-helpers/baseline_policy.cc
+--- qtwebengine-everywhere-src-5.15.2/src/3rdparty/chromium/sandbox/linux/seccomp-bpf-helpers/baseline_policy.cc	2020-11-07 02:22:36.000000000 +0100
++++ qtwebengine-everywhere-src-5.15.2-#1904652/src/3rdparty/chromium/sandbox/linux/seccomp-bpf-helpers/baseline_policy.cc	2021-01-20 02:14:53.066223906 +0100
+@@ -257,6 +257,18 @@
+     return RestrictKillTarget(current_pid, sysno);
+   }
+ 
++#if defined(__NR_newfstatat)
++  if (sysno == __NR_newfstatat) {
++    return RewriteFstatatSIGSYS();
++  }
++#endif
++
++#if defined(__NR_fstatat64)
++  if (sysno == __NR_fstatat64) {
++    return RewriteFstatatSIGSYS();
++  }
++#endif
++
+   if (SyscallSets::IsFileSystem(sysno) ||
+       SyscallSets::IsCurrentDirectory(sysno)) {
+     return Error(fs_denied_errno);
+diff -ur qtwebengine-everywhere-src-5.15.2/src/3rdparty/chromium/sandbox/linux/seccomp-bpf-helpers/sigsys_handlers.cc qtwebengine-everywhere-src-5.15.2-#1904652/src/3rdparty/chromium/sandbox/linux/seccomp-bpf-helpers/sigsys_handlers.cc
+--- qtwebengine-everywhere-src-5.15.2/src/3rdparty/chromium/sandbox/linux/seccomp-bpf-helpers/sigsys_handlers.cc	2020-11-07 02:22:36.000000000 +0100
++++ qtwebengine-everywhere-src-5.15.2-#1904652/src/3rdparty/chromium/sandbox/linux/seccomp-bpf-helpers/sigsys_handlers.cc	2021-01-22 19:02:55.651668257 +0100
+@@ -6,6 +6,8 @@
+ 
+ #include "sandbox/linux/seccomp-bpf-helpers/sigsys_handlers.h"
+ 
++#include <errno.h>
++#include <fcntl.h>
+ #include <stddef.h>
+ #include <stdint.h>
+ #include <string.h>
+@@ -355,6 +357,35 @@
+   return -ENOSYS;
+ }
+ 
++intptr_t SIGSYSFstatatHandler(const struct arch_seccomp_data& args,
++                            void* aux) {
++  switch (args.nr) {
++#if defined(__NR_newfstatat)
++    case __NR_newfstatat:
++#endif
++#if defined(__NR_fstatat64)
++    case __NR_fstatat64:
++#endif
++#if defined(__NR_newfstatat) || defined(__NR_fstatat64)
++      if (*reinterpret_cast<const char *>(args.args[1]) == '\0'
++          && args.args[3] == static_cast<uint64_t>(AT_EMPTY_PATH)) {
++        return sandbox::sys_fstat64(static_cast<int>(args.args[0]),
++                                    reinterpret_cast<struct stat64 *>(args.args[2]));
++      } else {
++        errno = EACCES;
++        return -1;
++      }
++      break;
++#endif
++  }
++
++  CrashSIGSYS_Handler(args, aux);
++
++  // Should never be reached.
++  RAW_CHECK(false);
++  return -ENOSYS;
++}
++
+ bpf_dsl::ResultExpr CrashSIGSYS() {
+   return bpf_dsl::Trap(CrashSIGSYS_Handler, NULL);
+ }
+@@ -387,6 +418,10 @@
+   return bpf_dsl::Trap(SIGSYSSchedHandler, NULL);
+ }
+ 
++bpf_dsl::ResultExpr RewriteFstatatSIGSYS() {
++  return bpf_dsl::Trap(SIGSYSFstatatHandler, NULL);
++}
++
+ void AllocateCrashKeys() {
+ #if !defined(OS_NACL_NONSFI)
+   if (seccomp_crash_key)
+diff -ur qtwebengine-everywhere-src-5.15.2/src/3rdparty/chromium/sandbox/linux/seccomp-bpf-helpers/sigsys_handlers.h qtwebengine-everywhere-src-5.15.2-#1904652/src/3rdparty/chromium/sandbox/linux/seccomp-bpf-helpers/sigsys_handlers.h
+--- qtwebengine-everywhere-src-5.15.2/src/3rdparty/chromium/sandbox/linux/seccomp-bpf-helpers/sigsys_handlers.h	2020-11-07 02:22:36.000000000 +0100
++++ qtwebengine-everywhere-src-5.15.2-#1904652/src/3rdparty/chromium/sandbox/linux/seccomp-bpf-helpers/sigsys_handlers.h	2021-01-20 02:11:04.583714199 +0100
+@@ -62,6 +62,10 @@
+ // sched_setparam(), sched_setscheduler()
+ SANDBOX_EXPORT intptr_t SIGSYSSchedHandler(const arch_seccomp_data& args,
+                                            void* aux);
++// If the fstatat syscall is actually a disguised fstat, calls the regular fstat
++// syscall, otherwise, crashes in the same way as CrashSIGSYS_Handler.
++SANDBOX_EXPORT intptr_t SIGSYSFstatatHandler(const struct arch_seccomp_data& args, 
++                                             void* aux);
+ 
+ // Variants of the above functions for use with bpf_dsl.
+ SANDBOX_EXPORT bpf_dsl::ResultExpr CrashSIGSYS();
+@@ -72,6 +76,7 @@
+ SANDBOX_EXPORT bpf_dsl::ResultExpr CrashSIGSYSFutex();
+ SANDBOX_EXPORT bpf_dsl::ResultExpr CrashSIGSYSPtrace();
+ SANDBOX_EXPORT bpf_dsl::ResultExpr RewriteSchedSIGSYS();
++SANDBOX_EXPORT bpf_dsl::ResultExpr RewriteFstatatSIGSYS();
+ 
+ // Allocates a crash key so that Seccomp information can be recorded.
+ void AllocateCrashKeys();
+diff -ur qtwebengine-everywhere-src-5.15.2/src/3rdparty/chromium/sandbox/linux/services/syscall_wrappers.cc qtwebengine-everywhere-src-5.15.2-#1904652/src/3rdparty/chromium/sandbox/linux/services/syscall_wrappers.cc
+--- qtwebengine-everywhere-src-5.15.2/src/3rdparty/chromium/sandbox/linux/services/syscall_wrappers.cc	2020-11-07 02:22:36.000000000 +0100
++++ qtwebengine-everywhere-src-5.15.2-#1904652/src/3rdparty/chromium/sandbox/linux/services/syscall_wrappers.cc	2021-01-20 02:41:12.033133269 +0100
+@@ -261,4 +261,13 @@
+ 
+ #endif  // defined(MEMORY_SANITIZER)
+ 
++SANDBOX_EXPORT int sys_fstat64(int fd, struct stat64 *buf)
++{
++#if defined(__NR_fstat64)
++    return syscall(__NR_fstat64, fd, buf);
++#else
++    return syscall(__NR_fstat, fd, buf);
++#endif
++}
++
+ }  // namespace sandbox
+diff -ur qtwebengine-everywhere-src-5.15.2/src/3rdparty/chromium/sandbox/linux/services/syscall_wrappers.h qtwebengine-everywhere-src-5.15.2-#1904652/src/3rdparty/chromium/sandbox/linux/services/syscall_wrappers.h
+--- qtwebengine-everywhere-src-5.15.2/src/3rdparty/chromium/sandbox/linux/services/syscall_wrappers.h	2020-11-07 02:22:36.000000000 +0100
++++ qtwebengine-everywhere-src-5.15.2-#1904652/src/3rdparty/chromium/sandbox/linux/services/syscall_wrappers.h	2021-01-20 02:40:26.499827829 +0100
+@@ -17,6 +17,7 @@
+ struct rlimit64;
+ struct cap_hdr;
+ struct cap_data;
++struct stat64;
+ 
+ namespace sandbox {
+ 
+@@ -84,6 +85,9 @@
+                                  const struct sigaction* act,
+                                  struct sigaction* oldact);
+ 
++// Recent glibc rewrites fstat to fstatat.
++SANDBOX_EXPORT int sys_fstat64(int fd, struct stat64 *buf);
++
+ }  // namespace sandbox
+ 
+ #endif  // SANDBOX_LINUX_SERVICES_SYSCALL_WRAPPERS_H_


### PR DESCRIPTION
Marked as draft as this should be merged into a new `5.15-21.08` branch.  
Try and see if the base app can be built against the `5.15-21.08` runtime without further changes, and create a test build to try, as build time is too long to do this locally.

Add the following patches:
 - glibc 2.33: fixes rendering with some sites, see https://bugzilla.redhat.com/show_bug.cgi?id=1904652.
 - harfbuzz 3.0.0: fixes compilation
 - icu 68: fix compilation of in-tree libxml2 as TRUE/FALSE macros were removed, see https://icu.unicode.org/download/68.
   runtime libxml2 cannot be used as icu support is disabled, reported at https://gitlab.com/freedesktop-sdk/freedesktop-sdk/-/issues/1336.
 - disable thin archives: fixes linking of libbrowser.a. apparently a binutils regresssion (thanks @refi64), see https://sourceware.org/bugzilla/show_bug.cgi?id=28138.

 The glib & harfbuzz patches were imported from the Arch Linux packaging of qt5-webengine.
