### PR TITLE
[branch/5.15-21.08] Publish builds faster

### DIFF
--- a/flathub.json
+++ b/flathub.json
@@ -1,4 +1,5 @@
 {
     "automerge-flathubbot-prs": false,
+    "publish-delay-hours": 1,
     "skip-appstream-check": true
 }


### PR DESCRIPTION
Set publish delay to the smallest possible value of one hour.
The default 3 hours delay is too long, apps need to wait on the base
app, and then their rebuilds also being held off.