### PR TITLE
Support Widevine

### DIFF
--- a/io.qt.qtwebengine.BaseApp.json
+++ b/io.qt.qtwebengine.BaseApp.json
@@ -8,6 +8,15 @@
     ],
     "runtime-version": "5.15-21.08",
     "separate-locales": false,
+    "add-extensions": {
+        "io.qt.qtwebengine.Extension": {
+            "directory": "webengine/extensions",
+            "version": "5.15-21.08",
+            "subdirectories": true,
+            "no-autodownload": true,
+            "autodelete": true
+        }
+    },
     "command": "QtWebEngineProcess",
     "modules": [
         {
@@ -74,6 +83,10 @@
                 {
                     "type": "patch",
                     "path": "patches/snappy-detection.patch"
+                },
+                {
+                    "type": "patch",
+                    "path": "patches/widevine-extension-path.patch"
                 },
                 {
                     "type": "patch",
@@ -157,6 +170,7 @@
                 "sed -e 's@\\($$QT_MODULE_INCLUDE_BASE \\)@\\1'${FLATPAK_DEST}'/include @' -i ${FLATPAK_DEST}/lib/mkspecs/modules/*.pri",
                 "sed -e 's@$$QT_MODULE_INCLUDE_BASE/@'${FLATPAK_DEST}'/include/@g' -i ${FLATPAK_DEST}/lib/mkspecs/modules/*.pri",
                 "sed -e 's@$$QT_MODULE_LIB_BASE@'${FLATPAK_DEST}'/lib@g' -i ${FLATPAK_DEST}/lib/mkspecs/modules/*.pri",
+                "install -dm755 ${FLATPAK_DEST}/webengine/extensions",
                 "install -Dm644 ${FLATPAK_ID}.metainfo.xml -t ${FLATPAK_DEST}/share/metainfo",
                 "install cleanup-BaseApp.sh -t ${FLATPAK_DEST}"
             ]

--- a/patches/widevine-extension-path.patch
+++ b/patches/widevine-extension-path.patch
@@ -1,0 +1,13 @@
+diff --git a/src/core/content_client_qt.cpp b/src/core/content_client_qt.cpp
+index 560cdbf5..75553590 100644
+--- a/src/core/content_client_qt.cpp
++++ b/src/core/content_client_qt.cpp
+@@ -353,6 +353,8 @@ static bool IsWidevineAvailable(base::FilePath *cdm_path,
+     }
+ #elif defined(Q_OS_LINUX)
+         pluginPaths << QStringLiteral("/opt/google/chrome/libwidevinecdm.so") // Old Google Chrome
++                    << QStringLiteral("/app/webengine/extensions/Widevine/extra/_platform_specific/linux_arm64/libwidevinecdm.so")
++                    << QStringLiteral("/app/webengine/extensions/Widevine/extra/_platform_specific/linux_x64/libwidevinecdm.so")
+ #if Q_PROCESSOR_WORDSIZE == 8
+                     << QStringLiteral("/opt/google/chrome/WidevineCdm/_platform_specific/linux_x64/libwidevinecdm.so")
+ #else


### PR DESCRIPTION
This set default paths for loading the Widevine shared library from an extension mount point.  
This designed to support a `io.qt.qtwebengine.Extension.Widevine` extension which will allow applications to play DRM protected content.  
Applications will need to create the `/app/webengine/extensions` mount point, and add the extension.

The extension is QtWebEngine specific, as full Chromium browsers have the `component_updater` (see`chrome/browser/component_updater`) that downloads the Widevine into `XDG_CONFIG_HOME/CHOROM_NAME`.

I don't expect the distribution of Widevine to be an issue, as we can fetch the binaries during `apply_extra`.

First user will be qutebrowser, but other apps could also take advantage of DRM support, possibly [qtwebflix](https://github.com/gort818/qtwebflix).