### PR TITLE
Add QtWebEngine dictionaries

### DIFF
--- a/io.qt.qtwebengine.BaseApp.json
+++ b/io.qt.qtwebengine.BaseApp.json
@@ -4,6 +4,7 @@
     "runtime": "org.kde.Platform",
     "sdk": "org.kde.Sdk",
     "sdk-extensions": [
+        "org.kde.Sdk.Locale",
         "org.freedesktop.Sdk.Extension.node14"
     ],
     "runtime-version": "5.15-21.08",
@@ -62,6 +63,10 @@
                     "url": "https://chromium.googlesource.com/catapult",
                     "commit": "5eedfe23148a234211ba477f76fc2ea2e8529189",
                     "dest": "src/3rdparty/chromium/third_party/catapult"
+                },
+                {
+                    "type": "patch",
+                    "path": "patches/dictionaries.patch"
                 },
                 {
                     "type": "patch",
@@ -161,6 +166,7 @@
                 "install cleanup-BaseApp.sh -t ${FLATPAK_DEST}"
             ]
         },
+        "qtwebengine-dictionaries/qtwebengine-dictionaries.json",
         "qt5-webview/qt5-webview.json"
     ]
 }

--- a/patches/dictionaries.patch
+++ b/patches/dictionaries.patch
@@ -1,0 +1,14 @@
+diff --git a/src/core/web_engine_library_info.cpp b/src/core/web_engine_library_info.cpp
+index 3a649227..d6266124 100644
+--- a/src/core/web_engine_library_info.cpp
++++ b/src/core/web_engine_library_info.cpp
+@@ -254,6 +254,9 @@ QString dictionariesPath()
+             candidatePaths << frameworkDictionariesPath;
+ #endif
+ 
++            QString flatpakDictionariesPath = "/app/qtwebengine_dictionaries";
++            candidatePaths << flatpakDictionariesPath;
++
+             QString libraryDictionariesPath = QLibraryInfo::location(QLibraryInfo::DataPath)
+                     % QDir::separator() % QLatin1String("qtwebengine_dictionaries");
+             candidatePaths << libraryDictionariesPath;

--- a/qtwebengine-dictionaries/install-qtwebengine-dictionaries
+++ b/qtwebengine-dictionaries/install-qtwebengine-dictionaries
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+# applications should set QTWEBENGINE_DICTIONARIES_PATH to this value
+QTWEBENGINE_DICTDIR=${FLATPAK_DEST}/qtwebengine_dictionaries
+
+APP_LOCDIR=${FLATPAK_DEST}/share/locale
+RUNTIME_DICTDIR=/usr/share/hunspell
+
+
+install -dm755 ${QTWEBENGINE_DICTDIR}
+
+# for each hundpell dictionary
+for f in ${RUNTIME_DICTDIR}/*.dic; do
+  loc=$(basename $f | sed 's/\.dic//')
+  loc_short=${loc%_*}
+  echo
+  echo "Converting ${loc} Hunspell dictionary to a QtWebEngine dictionary..."
+
+  # English locales are kept in the app, and not packaged as locale extensions,
+  # so these should be real files or symlinks to a target in the same folder
+  if [ $loc_short = en ]; then
+
+    # locale is a symlink, dictionary conversion is unneeded, so just create a similar symlink
+    if [ -L $f ]; then
+      real_loc=$(basename $(readlink $f) | sed 's/\.dic//')
+      echo "Skipping conversion: ${loc} dictionary is a symlink to the ${real_loc} dictionary!"
+      ln -s ${real_loc}.bdic ${QTWEBENGINE_DICTDIR}/${loc}.bdic
+
+    else
+      # try to convert and install if successful
+      if qwebengine_convert_dict $f ${loc}.bdic; then
+        install -Dm644 ${loc}.bdic -t ${QTWEBENGINE_DICTDIR}/
+      fi
+
+    fi
+  else
+    # avoid crashes on tabss and IGNORE directives, https://bugs.chromium.org/p/chromium/issues/detail?id=165056
+    if grep -Pq '^IGNORE|\t' ${RUNTIME_DICTDIR}/${loc}.aff; then
+      echo "Applying workarounds to ${loc} affix file..."
+      cp ${RUNTIME_DICTDIR}/${loc}.{aff,dic} ./
+      sed -i '/^IGNORE/d;s/\t/ /g' ${loc}.aff
+      f=${loc}.dic
+    fi
+
+      # try to convert, install and create symlink if successful
+    if qwebengine_convert_dict $f ${loc}.bdic; then
+      install -Dm644 ${loc}.bdic -t ${APP_LOCDIR}/${loc_short}/qtwebengine_dictionaries/
+      ln -sr ${APP_LOCDIR}/${loc_short}/qtwebengine_dictionaries/${loc}.bdic ${QTWEBENGINE_DICTDIR}/${loc}.bdic
+    fi
+  fi
+done

--- a/qtwebengine-dictionaries/qtwebengine-dictionaries.json
+++ b/qtwebengine-dictionaries/qtwebengine-dictionaries.json
@@ -1,0 +1,18 @@
+{
+    "name": "qtwebengine-dictionaries",
+    "buildsystem": "simple",
+    "build-options": {
+        "env": {
+            "QT_WEBENGINE_ICU_DATA_DIR": "/app/resources"
+        }
+    },
+    "build-commands": [
+        "./install-qtwebengine-dictionaries"
+    ],
+    "sources": [
+        {
+            "type": "file",
+            "path": "install-qtwebengine-dictionaries"
+        }
+    ]
+}


### PR DESCRIPTION
## Changes

- Convert Hunspell dictionaries from the runtime to QtWebEngine dictionaries (bdic) and package them.
- Dictionaries folder path is `/app/qtwebengine_dictionaries`. Thie should be the value of
  `QTWEBENGINE_DICTIONARIES_PATH` if the application explictly sets it.
- The dictionary files of non-English locales are installed into `/app/share/locale` for inclusion in
  Flatpak locale extensions, and symlinks are created in `/app/qtwebengine_dictionaries`.
- Patch QtWebEngine so it will fall back to `/app/qtwebengine_dictionaries` if `QTWEBENGINE_DICTIONARIES_PATH`
  was not set.
  This is similar to the default behavior of falling back to `QLibraryInfo::DataPath/qtwebengine_dictionaries`
  on standard distro, where QtWebEngine is installed into the same prefix as Qt.
