### PR TITLE
Build Chromium from latest commit in 87-based branch

### DIFF
--- a/io.qt.qtwebengine.BaseApp.json
+++ b/io.qt.qtwebengine.BaseApp.json
@@ -50,7 +50,15 @@
                         "tag-query": "first(.[].name | match( \"v5.15[\\\\d.]+-lts|v5.15[\\\\d.]+\" ) | .string)",
                         "version-query": "$tag | sub(\"^v\"; \"\")",
                         "timestamp-query": ".[] | select(.name==$tag) | .commit.created_at"
-                    }
+                    },
+                    "disable-submodules": true
+                },
+                {
+                    "type": "git",
+                    "url": "https://invent.kde.org/qt/qt/qtwebengine-chromium.git",
+                    "branch": "87-based",
+                    "commit": "d13d0924c4e18ecc4b79adf0fec142ee9a9eaa14",
+                    "dest": "src/3rdparty"
                 },
                 {
                     "type": "shell",

--- a/qt5-webview/qt5-webview.json
+++ b/qt5-webview/qt5-webview.json
@@ -23,8 +23,8 @@
         {
             "type": "git",
             "url": "https://invent.kde.org/qt/qt/qtwebview.git",
-            "tag": "v5.15.2",
-            "commit": "800926cc4e0ecfdb37a3b34486403354b66a37a4",
+            "tag": "v5.15.3-lts-lgpl",
+            "commit": "ec4de0cec2299f4ae0228ea2c71011e0520ca40e",
             "x-checker-data": {
                 "type": "json",
                 "url": "https://invent.kde.org/api/v4/projects/qt%2Fqt%2Fqtwebview/repository/tags",

--- a/qt5-webview/qt5-webview.json
+++ b/qt5-webview/qt5-webview.json
@@ -26,10 +26,9 @@
             "tag": "v5.15.2",
             "commit": "800926cc4e0ecfdb37a3b34486403354b66a37a4",
             "x-checker-data": {
-                "is-main-source": true,
                 "type": "json",
                 "url": "https://invent.kde.org/api/v4/projects/qt%2Fqt%2Fqtwebview/repository/tags",
-                "tag-query": "first(.[].name | match( \"v5.15[\\\\d.]+-lts|v5.15[\\\\d.]+\" ) | .string)",
+                "tag-query": "first(.[].name | match( \"v5.15[\\\\d.]+(-lts-lgpl|-lts)?\" ) | .string)",
                 "version-query": "$tag | sub(\"^v\"; \"\")",
                 "timestamp-query": ".[] | select(.name==$tag) | .commit.created_at"
             }


### PR DESCRIPTION
~~Untested, so mark as draft.~~  
This gets us the latest backported security fixes CVE-2022-0971 and CVE-2022-1096.  
Also, fix qt5-webview f-e-d-c properties, and bump to 5.15.3-lts-lgpl.