### PR TITLE
Add workflow for auto-updating non-default branches

### DIFF
--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -11,7 +11,7 @@ jobs:
     if: github.repository_owner == 'flathub'
     strategy:
       matrix:
-        branch: [ branch/6.2 ]
+        branch: [ branch/5.15-21.08, branch/6.2 ]
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -1,0 +1,28 @@
+name: Check for updates
+on:
+  schedule:
+    - cron: '0 */12 * * *'
+  workflow_dispatch: {}
+jobs:
+  flatpak-external-data-checker:
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/flathub/flatpak-external-data-checker
+    if: github.repository_owner == 'flathub'
+    strategy:
+      matrix:
+        branch: [ branch/6.2 ]
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ matrix.branch }}
+      - uses: docker://ghcr.io/flathub/flatpak-external-data-checker:latest
+        env:
+          GIT_AUTHOR_NAME: Flatpak External Data Checker
+          GIT_COMMITTER_NAME: Flatpak External Data Checker
+          GIT_AUTHOR_EMAIL: ${{ github.actor }}@users.noreply.github.com
+          GIT_COMMITTER_EMAIL: ${{ github.actor }}@users.noreply.github.com
+          EMAIL: ${{ github.actor }}@users.noreply.github.com
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          args: --update --never-fork io.qt.qtwebengine.BaseApp.json

--- a/flathub.json
+++ b/flathub.json
@@ -1,4 +1,5 @@
 {
     "automerge-flathubbot-prs": false,
+    "disable-external-data-checker": true,
     "skip-appstream-check": true
 }


### PR DESCRIPTION
Inspired from a similar workflow for org.winehq.Wine that was added by @gasinvein.

This runs flatpak-external-data-checker every 12 hours, and opens new PRs if something has changed.  
Like the flathubbot initiated f-e-d-c runs, if there's already an opened PR with similar changes, then another one won't be created.

The workflow can also be triggered manually from GitHub's Actions tab.  

~~This handles non-default branches, not the default `branch/5.15-21.08` which flathubbot already taking care of.  
Currently, only `branch/6.2` is set in the strategy matrix.~~  
**Update: Changed to run on all the maintained branches, and flathubbot f-e-d-c is disabled**

~~What missing here is allowing to trigger the workflow manually with `workflow_dispatch` on the default branch, and without having to add a separate workflow.  
I'll leave that for later.~~