### PR TITLE
CI: Workflow updates

### DIFF
--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -6,23 +6,21 @@ on:
 jobs:
   flatpak-external-data-checker:
     runs-on: ubuntu-latest
-    container:
-      image: ghcr.io/flathub/flatpak-external-data-checker
     if: github.repository_owner == 'flathub'
     strategy:
       matrix:
         branch: [ branch/5.15-21.08, branch/6.2 ]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           ref: ${{ matrix.branch }}
       - uses: docker://ghcr.io/flathub/flatpak-external-data-checker:latest
         env:
           GIT_AUTHOR_NAME: Flatpak External Data Checker
           GIT_COMMITTER_NAME: Flatpak External Data Checker
-          GIT_AUTHOR_EMAIL: ${{ github.actor }}@users.noreply.github.com
-          GIT_COMMITTER_EMAIL: ${{ github.actor }}@users.noreply.github.com
-          EMAIL: ${{ github.actor }}@users.noreply.github.com
+          GIT_AUTHOR_EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
+          GIT_COMMITTER_EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
+          EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           args: --update --never-fork io.qt.qtwebengine.BaseApp.json

--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -1,7 +1,7 @@
 name: Check for updates
 on:
   schedule:
-    - cron: '0 */12 * * *'
+    - cron: '0 */8 * * *'
   workflow_dispatch: {}
 jobs:
   flatpak-external-data-checker:


### PR DESCRIPTION
**CI: Follow the f-e-c-d example workflow**
- Use github-actions' email to avoid having commits associated with the person who merged the workflow.
- Drop unneeded container image property
- Use actions/checkout@v3

**CI: Run workflow every 8 hours**
12 hours interval is a bit too long.
8 hours interval is not too short to trigger too many updates due to git commits in the qtwebengine-chromium repository.
~~Note that this affects f-e-d-c's auto-merging feature, so if we want to merge faster, then we need shorter interval
between scheduled workflow runs.~~

~~**CI: Enable auto-merging f-e-d-c PRs**~~
~~After switching to build qtwebengine-chromium from latest commit, we started having a backlog of unmerged PRs.
Let's enable auto-merging, and let f-e-d-c merge that for us.~~ **edit: Removed as does not conform with Flathub's policy**