### PR TITLE
[branch/6.2] CI: Enable auto-merging f-e-d-c PRs

### DIFF
--- a/flathub.json
+++ b/flathub.json
@@ -1,4 +1,5 @@
 {
     "automerge-flathubbot-prs": false,
+    "disable-external-data-checker": true,
     "skip-appstream-check": true
 }

--- a/flathub.json
+++ b/flathub.json
@@ -1,5 +1,5 @@
 {
-    "automerge-flathubbot-prs": false,
+    "automerge-flathubbot-prs": true,
     "disable-external-data-checker": true,
     "skip-appstream-check": true
 }

--- a/io.qt.qtwebengine.BaseApp.json
+++ b/io.qt.qtwebengine.BaseApp.json
@@ -56,7 +56,7 @@
                     "type": "git",
                     "url": "https://invent.kde.org/qt/qt/qtwebengine-chromium.git",
                     "branch": "90-based",
-                    "commit": "fe38b68770525c78b18e0f382c3f20bca3b78b7e",
+                    "commit": "dd5f07966de18c3fc23a2dc5e2d853714e1ad61f",
                     "dest": "src/3rdparty"
                 },
                 {


### PR DESCRIPTION
Following a similar change to the default branch in #64 

**CI: Enable auto-merging f-e-d-c PRs**
After switching to build qtwebengine-chromium from latest commit, we started having a backlog of unmerged PRs.
Let's enable auto-merging, and let f-e-d-c merge that for us.

**CI: Disable flathubbot's f-e-d-c checks**
Sync with the default branch. This is actually not need, but this way we have fewer changes between maintained branches.

**qtwebengine-chromium: Update to dd5f0796**