### PR TITLE
RFC: build with debuginfo in package

### DIFF
--- a/io.qt.qtwebengine.BaseApp.json
+++ b/io.qt.qtwebengine.BaseApp.json
@@ -10,6 +10,9 @@
     "runtime-version": "5.15-21.08",
     "separate-locales": false,
     "command": "QtWebEngineProcess",
+    "build-options": {
+        "no-debuginfo": true
+    },
     "modules": [
         {
             "name": "qt5-qtwebengine",


### PR DESCRIPTION
Update: this was an experiment that was succesful.

Simply, when building a package, flatpak will split out the debug info into a new package. But when using a baseapp that mean we copy the binaries without debuginfo and we never get them in the final app package, which mean that it's impossible to debug.

The main reason I wanted the debuginfo was for https://github.com/flathub/org.freecadweb.FreeCAD/pull/63 : tl;dr it was crashing and the stack trace were useless. With stacktrace I was able to pinpoint that the env wasn't set properly and QtWebEngine crashes try to out the message that the env wasn't set properly.

If you agree with the change, then I'll refine the PR. If you don't think it's worth it, I'll just close this.

DO NOT MERGE

~~I need this to test something (FreeCAD crashing with WebEngine + pyside2)~~ success