### PR TITLE
[branch/6.2] Sync with 6.3 changes and stop building latest Chromium commit

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-# Redemption
+# QtWebEngine BaseApp
 
-Yes. This is a hack. I also am not happy about it.
-
-Python2 is dead but chromium (hence QtWebEngine) still needs it. We have to live with it. This is how I'm coping.
+Please visit [the wiki](https://github.com/flathub/io.qt.qtwebengine.BaseApp/wiki) for more details and examples.

--- a/flathub.json
+++ b/flathub.json
@@ -1,4 +1,5 @@
 {
     "automerge-flathubbot-prs": false,
+    "require-important-update": true,
     "skip-appstream-check": true
 }

--- a/io.qt.qtwebengine.BaseApp.json
+++ b/io.qt.qtwebengine.BaseApp.json
@@ -49,15 +49,7 @@
                         "tag-query": "first(.[].name | match( \"v6.2[\\\\d.]+-lts|v6.2[\\\\d.]+\" ) | .string)",
                         "version-query": "$tag | sub(\"^v\"; \"\")",
                         "timestamp-query": ".[] | select(.name==$tag) | .commit.created_at"
-                    },
-                    "disable-submodules": true
-                },
-                {
-                    "type": "git",
-                    "url": "https://invent.kde.org/qt/qt/qtwebengine-chromium.git",
-                    "branch": "90-based",
-                    "commit": "3e8444fbf852db7b5470e2088cec378547100215",
-                    "dest": "src/3rdparty"
+                    }
                 },
                 {
                     "type": "shell",

--- a/qt6-webview/qt6-webview.json
+++ b/qt6-webview/qt6-webview.json
@@ -23,7 +23,8 @@
         "sed -e 's@\\($$QT_MODULE_BIN_BASE\\)@\\1 '${FLATPAK_DEST}'/bin @' -i ${FLATPAK_DEST}/mkspecs/modules/qt_lib_webview*.pri",
         "sed -e 's@\\($$QT_MODULE_INCLUDE_BASE \\)@\\1'${FLATPAK_DEST}'/include @' -i ${FLATPAK_DEST}/mkspecs/modules/qt_lib_webview*.pri",
         "sed -e 's@$$QT_MODULE_INCLUDE_BASE/@'${FLATPAK_DEST}'/include/@g' -i ${FLATPAK_DEST}/mkspecs/modules/qt_lib_webview*.pri",
-        "sed -e 's@$$QT_MODULE_LIB_BASE@'${FLATPAK_DEST}'/lib@g' -i ${FLATPAK_DEST}/mkspecs/modules/qt_lib_webview*.pri"
+        "sed -e 's@$$QT_MODULE_LIB_BASE@'${FLATPAK_DEST}'/lib@g' -i ${FLATPAK_DEST}/mkspecs/modules/qt_lib_webview*.pri",
+        "ln -sr ${FLATPAK_DEST}/lib/${FLATPAK_ARCH}-linux-gnu/libQt*WebView.so* -t ${FLATPAK_DEST}/lib/"
     ],
     "sources": [
         {

--- a/qt6-webview/qt6-webview.json
+++ b/qt6-webview/qt6-webview.json
@@ -33,6 +33,7 @@
             "tag": "v6.2.4",
             "commit": "4648d5d9ad50171a9f6e8fe8803cc92c12740baf",
             "x-checker-data": {
+                "is-important": true,
                 "type": "json",
                 "url": "https://invent.kde.org/api/v4/projects/qt%2Fqt%2Fqtwebview/repository/tags",
                 "tag-query": "first(.[].name | match( \"v6.2[\\\\d.]+(-lts-lgpl|-lts)?\" ) | .string)",

--- a/qtwebengine-dictionaries/install-qtwebengine-dictionaries
+++ b/qtwebengine-dictionaries/install-qtwebengine-dictionaries
@@ -9,15 +9,15 @@ RUNTIME_DICTDIR=/usr/share/hunspell
 
 install -dm755 ${QTWEBENGINE_DICTDIR}
 
-# for each hundpell dictionary
+# for each hunspell dictionary
 for f in ${RUNTIME_DICTDIR}/*.dic; do
   loc=$(basename $f | sed 's/\.dic//')
   loc_short=${loc%_*}
   echo
   echo "Converting ${loc} Hunspell dictionary to a QtWebEngine dictionary..."
 
-  # English locales are kept in the app, and not packaged as locale extensions,
-  # so these should be real files or symlinks to a target in the same folder
+  # English locales are kept in the app, and are not packaged as locale extensions,
+  # so these should be real files or symlinks to targets in the same folder
   if [ $loc_short = en ]; then
 
     # locale is a symlink, dictionary conversion is unneeded, so just create a similar symlink
@@ -27,14 +27,14 @@ for f in ${RUNTIME_DICTDIR}/*.dic; do
       ln -s ${real_loc}.bdic ${QTWEBENGINE_DICTDIR}/${loc}.bdic
 
     else
-      # try to convert and install if successful
+      # try to convert and install only if successful
       if qwebengine_convert_dict $f ${loc}.bdic; then
         install -Dm644 ${loc}.bdic -t ${QTWEBENGINE_DICTDIR}/
       fi
 
     fi
   else
-    # avoid crashes on tabss and IGNORE directives, https://bugs.chromium.org/p/chromium/issues/detail?id=165056
+    # avoid crashes on tabs and IGNORE directives, https://bugs.chromium.org/p/chromium/issues/detail?id=165056
     if grep -Pq '^IGNORE|\t' ${RUNTIME_DICTDIR}/${loc}.aff; then
       echo "Applying workarounds to ${loc} affix file..."
       cp ${RUNTIME_DICTDIR}/${loc}.{aff,dic} ./

--- a/re2/re2.json
+++ b/re2/re2.json
@@ -8,8 +8,8 @@
     "sources": [
         {
             "type": "archive",
-            "url": "https://github.com/google/re2/archive/2022-04-01/re2-2022-04-01.tar.gz",
-            "sha256": "1ae8ccfdb1066a731bba6ee0881baad5efd2cd661acd9569b689f2586e1a50e9",
+            "url": "https://github.com/google/re2/archive/2022-06-01/re2-2022-06-01.tar.gz",
+            "sha256": "f89c61410a072e5cbcf8c27e3a778da7d6fd2f2b5b1445cd4f4508bee946ab0f",
             "x-checker-data": {
                 "type": "anitya",
                 "project-id": 10500,


### PR DESCRIPTION
With the added 6.3 branch, we need to take a few steps to lower the number of updates, PRs and test builds.  

- The first step which is included in this PR is to avoid building Chromium from the latest commit in git.  
- The next step, which is not included here in order to keep the 6.2 PR merge-able, is to remove the flatpak-external-data-checker properties from all the Flatpak modules that are not Qt modules, or at least until the selective updates PR will be merged to f-e-d-c.
- Maybe mark the 6.2 as EOL early, and after confirming that all relevant apps switched to 6.3.

**Changes**

- QtWebEngine: Use Chromium commit from stable instead of the latest committed.  
Stop fetching the latest commit to qtwebengine-chromium's 90-based branch, and build from the commit set in the stable
QtWebEngine release tag.
It's less important to have the latest Chromium fixes, but more to avoid overburdening the maintainer.
- Update re2 to 2022-06-01
- qt6-webview: Add shared lib symlinks in lib/
- qtwebengine-dictionaries: Fix typos and other errors in comments
- qt6-webview: Set source as important for selective f-e-d-c updates
- flathub.json: Activate selective f-e-d-c updates.
**This will do nothing** as we're using our own Github workflow, but let's set this for the possibility that flathubbot
will support checking multiple branches.
- README.md: Link to the wiki

Supersedes #82, #84, #95