### PR TITLE
[branch/5.15-21.08] Add 6.3 branch to GH workflow, update modules, and sync with 6.3 branch changes

### DIFF
--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -23,4 +23,4 @@ jobs:
           EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          args: --update --never-fork io.qt.qtwebengine.BaseApp.json
+          args: --update --never-fork --require-important-update io.qt.qtwebengine.BaseApp.json

--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -9,7 +9,7 @@ jobs:
     if: github.repository_owner == 'flathub'
     strategy:
       matrix:
-        branch: [ branch/5.15-21.08, branch/6.2 ]
+        branch: [ branch/5.15-21.08, branch/6.2, branch/6.3 ]
     steps:
       - uses: actions/checkout@v3
         with:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-# Redemption
+# QtWebEngine BaseApp
 
-Yes. This is a hack. I also am not happy about it.
-
-Python2 is dead but chromium (hence QtWebEngine) still needs it. We have to live with it. This is how I'm coping.
+Please visit [the wiki](https://github.com/flathub/io.qt.qtwebengine.BaseApp/wiki) for more details and examples.

--- a/flathub.json
+++ b/flathub.json
@@ -1,5 +1,6 @@
 {
     "automerge-flathubbot-prs": false,
     "disable-external-data-checker": true,
+    "require-important-update": true,
     "skip-appstream-check": true
 }

--- a/io.qt.qtwebengine.BaseApp.json
+++ b/io.qt.qtwebengine.BaseApp.json
@@ -56,9 +56,16 @@
                 {
                     "type": "git",
                     "url": "https://invent.kde.org/qt/qt/qtwebengine-chromium.git",
-                    "branch": "87-based",
                     "commit": "0910b2b2c2eb8de4b062a1454803b9eda6420a1b",
-                    "dest": "src/3rdparty"
+                    "dest": "src/3rdparty",
+                    "x-checker-data": {
+                        "is-important": true,
+                        "type": "json",
+                        "url": "https://invent.kde.org/api/v4/projects/qt%2Fqt%2Fqtwebengine-chromium/repository/commits?ref_name=87-based",
+                        "commit-query": "first( .[].id )",
+                        "version-query": "first( .[].short_id )",
+                        "timestamp-query": "first( .[].committed_date )"
+                    }
                 },
                 {
                     "type": "shell",

--- a/io.qt.qtwebengine.BaseApp.json
+++ b/io.qt.qtwebengine.BaseApp.json
@@ -41,8 +41,8 @@
                 {
                     "type": "git",
                     "url": "https://invent.kde.org/qt/qt/qtwebengine.git",
-                    "tag": "v5.15.9-lts",
-                    "commit": "4f570bd7add21725d66ac8396dcf21917c3a603f",
+                    "tag": "v5.15.10-lts",
+                    "commit": "c7e716ef1ffd63a8ab1f4dbf879230849eb3b505",
                     "x-checker-data": {
                         "is-main-source": true,
                         "type": "json",
@@ -57,7 +57,7 @@
                     "type": "git",
                     "url": "https://invent.kde.org/qt/qt/qtwebengine-chromium.git",
                     "branch": "87-based",
-                    "commit": "7857ff290ab254a5a1fe2e85e146680448b4d46e",
+                    "commit": "0910b2b2c2eb8de4b062a1454803b9eda6420a1b",
                     "dest": "src/3rdparty"
                 },
                 {

--- a/io.qt.qtwebengine.BaseApp.metainfo.xml
+++ b/io.qt.qtwebengine.BaseApp.metainfo.xml
@@ -8,6 +8,7 @@
   <url type="homepage">https://qt.io</url>
   <project_group>KDE</project_group>
   <releases>
+    <release version="5.15.10-lts" date="2022-05-24"/>
     <release version="5.15.9-lts" date="2022-03-30"/>
     <release version="5.15.8-lts" date="2021-12-15"/>
     <release version="5.15.7-lts" date="2021-10-20"/>

--- a/krb5/krb5.json
+++ b/krb5/krb5.json
@@ -13,8 +13,8 @@
     "sources": [
         {
             "type": "archive",
-            "url": "https://kerberos.org/dist/krb5/1.19/krb5-1.19.3.tar.gz",
-            "sha256": "56d04863cfddc9d9eb7af17556e043e3537d41c6e545610778676cf551b9dcd0",
+            "url": "https://kerberos.org/dist/krb5/1.20/krb5-1.20.tar.gz",
+            "sha256": "7e022bdd3c851830173f9faaa006a230a0e0fdad4c953e85bff4bf0da036e12f",
             "x-checker-data": {
                 "type": "html",
                 "url": "https://kerberos.org/dist/",

--- a/qt5-webview/qt5-webview.json
+++ b/qt5-webview/qt5-webview.json
@@ -17,7 +17,8 @@
         "sed -e 's@\\($$QT_MODULE_BIN_BASE\\)@\\1 '${FLATPAK_DEST}'/bin @' -i ${FLATPAK_DEST}/lib/mkspecs/modules/qt_lib_webview*.pri",
         "sed -e 's@\\($$QT_MODULE_INCLUDE_BASE \\)@\\1'${FLATPAK_DEST}'/include @' -i ${FLATPAK_DEST}/lib/mkspecs/modules/qt_lib_webview*.pri",
         "sed -e 's@$$QT_MODULE_INCLUDE_BASE/@'${FLATPAK_DEST}'/include/@g' -i ${FLATPAK_DEST}/lib/mkspecs/modules/qt_lib_webview*.pri",
-        "sed -e 's@$$QT_MODULE_LIB_BASE@'${FLATPAK_DEST}'/lib@g' -i ${FLATPAK_DEST}/lib/mkspecs/modules/qt_lib_webview*.pri"
+        "sed -e 's@$$QT_MODULE_LIB_BASE@'${FLATPAK_DEST}'/lib@g' -i ${FLATPAK_DEST}/lib/mkspecs/modules/qt_lib_webview*.pri",
+        "ln -sr ${FLATPAK_DEST}/lib/${FLATPAK_ARCH}-linux-gnu/libQt*WebView.so* -t ${FLATPAK_DEST}/lib/"
     ],
     "sources": [
         {

--- a/qt5-webview/qt5-webview.json
+++ b/qt5-webview/qt5-webview.json
@@ -27,6 +27,7 @@
             "tag": "v5.15.5-lts-lgpl",
             "commit": "429096eb954672d3727a3e8cc83832bc79cf7967",
             "x-checker-data": {
+                "is-important": true,
                 "type": "json",
                 "url": "https://invent.kde.org/api/v4/projects/qt%2Fqt%2Fqtwebview/repository/tags",
                 "tag-query": "first(.[].name | match( \"v5.15[\\\\d.]+(-lts-lgpl|-lts)?\" ) | .string)",

--- a/qt5-webview/qt5-webview.json
+++ b/qt5-webview/qt5-webview.json
@@ -23,8 +23,8 @@
         {
             "type": "git",
             "url": "https://invent.kde.org/qt/qt/qtwebview.git",
-            "tag": "v5.15.4-lts-lgpl",
-            "commit": "826d2a33929c69807917536d48b7861e7682001e",
+            "tag": "v5.15.5-lts-lgpl",
+            "commit": "429096eb954672d3727a3e8cc83832bc79cf7967",
             "x-checker-data": {
                 "type": "json",
                 "url": "https://invent.kde.org/api/v4/projects/qt%2Fqt%2Fqtwebview/repository/tags",

--- a/qtwebengine-dictionaries/install-qtwebengine-dictionaries
+++ b/qtwebengine-dictionaries/install-qtwebengine-dictionaries
@@ -9,15 +9,15 @@ RUNTIME_DICTDIR=/usr/share/hunspell
 
 install -dm755 ${QTWEBENGINE_DICTDIR}
 
-# for each hundpell dictionary
+# for each hunspell dictionary
 for f in ${RUNTIME_DICTDIR}/*.dic; do
   loc=$(basename $f | sed 's/\.dic//')
   loc_short=${loc%_*}
   echo
   echo "Converting ${loc} Hunspell dictionary to a QtWebEngine dictionary..."
 
-  # English locales are kept in the app, and not packaged as locale extensions,
-  # so these should be real files or symlinks to a target in the same folder
+  # English locales are kept in the app, and are not packaged as locale extensions,
+  # so these should be real files or symlinks to targets in the same folder
   if [ $loc_short = en ]; then
 
     # locale is a symlink, dictionary conversion is unneeded, so just create a similar symlink
@@ -27,14 +27,14 @@ for f in ${RUNTIME_DICTDIR}/*.dic; do
       ln -s ${real_loc}.bdic ${QTWEBENGINE_DICTDIR}/${loc}.bdic
 
     else
-      # try to convert and install if successful
+      # try to convert and install only if successful
       if qwebengine_convert_dict $f ${loc}.bdic; then
         install -Dm644 ${loc}.bdic -t ${QTWEBENGINE_DICTDIR}/
       fi
 
     fi
   else
-    # avoid crashes on tabss and IGNORE directives, https://bugs.chromium.org/p/chromium/issues/detail?id=165056
+    # avoid crashes on tabs and IGNORE directives, https://bugs.chromium.org/p/chromium/issues/detail?id=165056
     if grep -Pq '^IGNORE|\t' ${RUNTIME_DICTDIR}/${loc}.aff; then
       echo "Applying workarounds to ${loc} affix file..."
       cp ${RUNTIME_DICTDIR}/${loc}.{aff,dic} ./

--- a/re2/re2.json
+++ b/re2/re2.json
@@ -8,8 +8,8 @@
     "sources": [
         {
             "type": "archive",
-            "url": "https://github.com/google/re2/archive/2022-04-01/re2-2022-04-01.tar.gz",
-            "sha256": "1ae8ccfdb1066a731bba6ee0881baad5efd2cd661acd9569b689f2586e1a50e9",
+            "url": "https://github.com/google/re2/archive/2022-06-01/re2-2022-06-01.tar.gz",
+            "sha256": "f89c61410a072e5cbcf8c27e3a778da7d6fd2f2b5b1445cd4f4508bee946ab0f",
             "x-checker-data": {
                 "type": "anitya",
                 "project-id": 10500,


### PR DESCRIPTION
**Changes**

- Update modules:
  - Update krb5-1.19.3.tar.gz to 1.20
  - Update re2-2022-04-01.tar.gz to 2022-06-01
  - Update qtwebengine.git to 5.15.10-lts
  - Update qtwebengine-chromium.git
  - Update qtwebview.git to 5.15.5-lts-lgpl

- qt5-webview: Add shared lib symlinks in lib/
- qtwebengine-dictionaries: Fix typos and other errors in comments
- qt5-webview: Set source as important for selective f-e-d-c updates
- flathub.json: Activate selective f-e-d-c updates  
This will do nothing as we're using our own Github workflow, but let's set this for the possibility that flathubbot
will support checking multiple branches.
- README.md: Link to the wiki
- CI: Add 6.3 branch to workflow
- qtwebengine-chromium: Use JSON checker, don't break on outdated commit
- CI: Require important updates to open PR  
This means that the GitHub workflow will only open a PR if the following are outdated:
  - QtWebEngine
  - qtwebengine-chromium (only in the 5.15-21.08 and 6.3 branches)
  - QtWebView

Supersedes #79, #81, #83, #85, #86, #87, #88, #90, #96.