### PR TITLE
Stop updating EOL branches

### DIFF
--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -9,7 +9,7 @@ jobs:
     if: github.repository_owner == 'flathub'
     strategy:
       matrix:
-        branch: [ branch/5.15-22.08, branch/6.2, branch/6.3 ]
+        branch: [ branch/5.15-22.08, branch/6.5 ]
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
Both 6.2 and 6.3 branches are EOL therefore it doesn't make sense to try updating them especially when those updates are broken for a long time. Add 6.5 branch instead