### PR TITLE
Update qt5-webengine to 5.15.15 (22.08 edition)

### DIFF
--- a/io.qt.qtwebengine.BaseApp.json
+++ b/io.qt.qtwebengine.BaseApp.json
@@ -85,21 +85,14 @@
                 },
                 {
                     "type": "patch",
-                    "path": "patches/chromium-add-app-libdir.patch",
-                    "options": [
-                        "--directory=src/3rdparty"
-                    ]
-                },
-                {
-                    "type": "patch",
                     "path": "patches/python3.patch"
                 },
                 {
                     "type": "patch",
                     "paths": [
+                        "patches/chromium-add-app-libdir.patch",
                         "patches/chromium-python3.patch",
                         "patches/chromium-pipewire03.patch",
-                        "patches/chromium-python310.patch",
                         "patches/qtwebengine-chromium-gcc12.patch"
                     ],
                     "options": [

--- a/io.qt.qtwebengine.BaseApp.json
+++ b/io.qt.qtwebengine.BaseApp.json
@@ -40,8 +40,8 @@
                 {
                     "type": "git",
                     "url": "https://invent.kde.org/qt/qt/qtwebengine.git",
-                    "tag": "v5.15.13-lts",
-                    "commit": "a3ca44e5b92c5a0dc7d90337c651c9bdb838ac93",
+                    "tag": "v5.15.15-lts",
+                    "commit": "21ddfe15f638a36160cb11d00639c3126c1aed7c",
                     "x-checker-data": {
                         "type": "git",
                         "tag-pattern": "^(v5.15.*-lts)$"
@@ -51,9 +51,9 @@
                 {
                     "type": "git",
                     "url": "https://invent.kde.org/qt/qt/qtwebengine-chromium.git",
-                    "commit": "e48df7803c7c98b0b2471c94057d32e44a301ad5",
+                    "commit": "8df91f886e7fffb61408e2426f8a90d763a3b6ea",
                     "dest": "src/3rdparty",
-                    "----": "cannot use x-checker-data, should be using the one https://invent.kde.org/qt/qt/qtwebengine.git points at as a submodule"
+                    "//": "cannot use x-checker-data, should be using the one https://invent.kde.org/qt/qt/qtwebengine.git points at as a submodule"
                 },
                 {
                     "type": "shell",
@@ -64,7 +64,7 @@
                 {
                     "type": "git",
                     "url": "https://chromium.googlesource.com/catapult",
-                    "commit": "5eedfe23148a234211ba477f76fc2ea2e8529189",
+                    "commit": "9e2d977782dcc3d14e7cb15614399f8d531c962a",
                     "dest": "src/3rdparty/chromium/third_party/catapult"
                 },
                 {

--- a/io.qt.qtwebengine.BaseApp.metainfo.xml
+++ b/io.qt.qtwebengine.BaseApp.metainfo.xml
@@ -8,6 +8,7 @@
   <url type="homepage">https://qt.io</url>
   <project_group>KDE</project_group>
   <releases>
+    <release version="5.15.15-lts" date="2023-07-10"/>
     <release version="5.15.13-lts" date="2023-02-27"/>
     <release version="5.15.10-lts" date="2022-05-24"/>
     <release version="5.15.9-lts" date="2022-03-30"/>

--- a/krb5/krb5.json
+++ b/krb5/krb5.json
@@ -13,8 +13,8 @@
     "sources": [
         {
             "type": "archive",
-            "url": "https://kerberos.org/dist/krb5/1.20/krb5-1.20.1.tar.gz",
-            "sha256": "704aed49b19eb5a7178b34b2873620ec299db08752d6a8574f95d41879ab8851",
+            "url": "https://kerberos.org/dist/krb5/1.21/krb5-1.21.2.tar.gz",
+            "sha256": "9560941a9d843c0243a71b17a7ac6fe31c7cebb5bce3983db79e52ae7e850491",
             "x-checker-data": {
                 "type": "html",
                 "url": "https://kerberos.org/dist/",

--- a/minizip/minizip.json
+++ b/minizip/minizip.json
@@ -7,8 +7,8 @@
     "sources": [
         {
             "type": "archive",
-            "url": "https://zlib.net/zlib-1.2.13.tar.gz",
-            "sha256": "b3a24de97a8fdbc835b9833169501030b8977031bcb54b3b3ac13740f846ab30",
+            "url": "https://zlib.net/zlib-1.3.tar.gz",
+            "sha256": "ff0ba4c292013dbc27530b3a81e1f9a813cd39de01ca5e0f8bf355702efa593e",
             "x-checker-data": {
                 "type": "anitya",
                 "project-id": 5303,

--- a/patches/chromium-python3.patch
+++ b/patches/chromium-python3.patch
@@ -1769,3 +1769,16 @@ index d47c398259b..2702b68b9bd 100755
  
    if options.output_cc:
      out_cc.close()
+diff --git a/chromium/third_party/jinja2/tests.py b/chromium/third_party/jinja2/tests.py
+index 0adc3d4dbcb..b14f85ff148 100644
+--- a/chromium/third_party/jinja2/tests.py
++++ b/chromium/third_party/jinja2/tests.py
+@@ -10,7 +10,7 @@
+ """
+ import operator
+ import re
+-from collections import Mapping
++from collections.abc import Mapping
+ from jinja2.runtime import Undefined
+ from jinja2._compat import text_type, string_types, integer_types
+ import decimal

--- a/pciutils/pciutils.json
+++ b/pciutils/pciutils.json
@@ -16,8 +16,8 @@
     "sources": [
         {
             "type": "archive",
-            "url": "https://mj.ucw.cz/download/linux/pci/pciutils-3.9.0.tar.gz",
-            "sha256": "8953a785b2e3af414434b8fdcbfb75c90758819631001e60dd3afb89b22b2331",
+            "url": "https://mj.ucw.cz/download/linux/pci/pciutils-3.10.0.tar.gz",
+            "sha256": "7deabe38ae5fa88a96a8c4947975cf31c591506db546e9665a10dddbf350ead0",
             "x-checker-data": {
                 "type": "anitya",
                 "project-id": 2605,

--- a/qt5-webview/qt5-webview.json
+++ b/qt5-webview/qt5-webview.json
@@ -24,8 +24,8 @@
         {
             "type": "git",
             "url": "https://invent.kde.org/qt/qt/qtwebview.git",
-            "tag": "v5.15.9-lts-lgpl",
-            "commit": "23d67d0de3301dbed5d8c5880b6cf60bfa9eeb2a",
+            "tag": "v5.15.11-lts-lgpl",
+            "commit": "f078642eb9a440f6aa88f2beaf10f445de1e29bb",
             "x-checker-data": {
                 "type": "git",
                 "tag-pattern": "^(v5.15.*-lts-lgpl)$"


### PR DESCRIPTION
The intention is to update it to 5.15.15 for the 22.08 branch since I closed all PRs opened by the bot.

Same as https://github.com/flathub/io.qt.qtwebengine.BaseApp/pull/314 minus the last 3 commits