### PR TITLE
Copy Qt module pkgconfig files to `/app/lib/pkgconfig`

### DIFF
--- a/io.qt.qtwebengine.BaseApp.json
+++ b/io.qt.qtwebengine.BaseApp.json
@@ -143,6 +143,14 @@
             ]
         },
         "qtwebengine-dictionaries/qtwebengine-dictionaries.json",
-        "qt6-webview/qt6-webview.json"
+        "qt6-webview/qt6-webview.json",
+        {
+            "name": "copy-pkgconfig",
+            "buildsystem": "simple",
+            "build-commands": [
+                "mkdir -p  ${FLATPAK_DEST}/lib/pkgconfig",
+                "cp -nv ${FLATPAK_DEST}/lib/$(gcc --print-multiarch)/pkgconfig/*.pc ${FLATPAK_DEST}/lib/pkgconfig"
+            ]
+        }
     ]
 }


### PR DESCRIPTION
Fixes https://github.com/flathub/io.qt.qtwebengine.BaseApp/issues/205

Needs backport to branch/6.5, branch/5.15-22.08, branch/5.15-23.08