### PR TITLE
Bump to Qt 6.10.1

### DIFF
--- a/io.qt.qtwebengine.BaseApp.json
+++ b/io.qt.qtwebengine.BaseApp.json
@@ -42,8 +42,8 @@
                 {
                     "type": "git",
                     "url": "https://invent.kde.org/qt/qt/qtwebengine.git",
-                    "tag": "v6.10.0",
-                    "commit": "08cfa1af1eaa001a731e21bee336f09677a9c88a",
+                    "tag": "v6.10.1",
+                    "commit": "28eb5425c6abef3938fb82a48427d45d1dd4e64f",
                     "x-checker-data": {
                         "is-main-source": true,
                         "type": "json",

--- a/qt6-webview/qt6-webview.json
+++ b/qt6-webview/qt6-webview.json
@@ -29,8 +29,8 @@
         {
             "type": "git",
             "url": "https://invent.kde.org/qt/qt/qtwebview.git",
-            "tag": "v6.10.0",
-            "commit": "293f95f9cfcdbfac60f8276ad5f50d234257557f",
+            "tag": "v6.10.1",
+            "commit": "86a71b5a88494368557d7c2c083287f15d5cd0e7",
             "x-checker-data": {
                 "is-important": true,
                 "type": "json",


### PR DESCRIPTION
As org.kde.Sdk moved to 6.10.1 now, here's a PR for the webengine to have it in sync.