### PR TITLE
Fix screen sharing dialogs

### DIFF
--- a/io.qt.qtwebengine.BaseApp.json
+++ b/io.qt.qtwebengine.BaseApp.json
@@ -73,6 +73,10 @@
                 },
                 {
                     "type": "patch",
+                    "path": "patches/qtwebengine-pipewire-screen.patch"
+                },
+                {
+                    "type": "patch",
                     "paths": [
                         "patches/chromium-add-app-libdir.patch",
                         "patches/chromium-flatpak-add-initial-sandbox-support.patch",

--- a/minizip/minizip.json
+++ b/minizip/minizip.json
@@ -7,14 +7,18 @@
     "sources": [
         {
             "type": "archive",
-            "url": "https://zlib.net/zlib-1.3.1.tar.gz",
-            "sha256": "9a93b2b7dfdac77ceba5a558a580e74667dd6fede4585b91eefb60f03b72df23",
+            "url": "https://zlib.net/zlib-1.3.2.tar.gz",
+            "sha256": "bb329a0a2cd0274d05519d61c667c062e06990d72e125ee2dfa8de64f0119d16",
             "x-checker-data": {
                 "type": "anitya",
                 "project-id": 5303,
                 "stable-only": true,
                 "url-template": "https://zlib.net/zlib-$version.tar.gz"
             }
+        },
+        {
+            "type": "patch",
+            "path": "patches/minizip-headers.patch"
         },
         {
             "type": "shell",

--- a/minizip/patches/minizip-headers.patch
+++ b/minizip/patches/minizip-headers.patch
@@ -1,0 +1,11 @@
+diff -Naur a/contrib/minizip/Makefile.am b/contrib/minizip/Makefile.am
+--- a/contrib/minizip/Makefile.am	2012-03-27 05:17:41.000000000 +0200
++++ b/contrib/minizip/Makefile.am	2026-05-14 13:30:44.347495566 +0200
+@@ -30,6 +30,7 @@
+ 	ioapi.h \
+ 	mztools.h \
+ 	unzip.h \
++	ints.h \
+ 	zip.h \
+ 	${iowin32_h}
+ 

--- a/patches/qtwebengine-pipewire-screen.patch
+++ b/patches/qtwebengine-pipewire-screen.patch
@@ -1,0 +1,32 @@
+--- a/src/core/desktop_media_controller.cpp
++++ b/src/core/desktop_media_controller.cpp
+@@ -113,13 +113,26 @@ void DesktopMediaListQtPrivate::init()
+     // This makes direct 'selectScreen/Window' calls possible from the frontend.
+     // Note: StartUpdating should be called after Update is completed as it can overwrite the
+     // internal cb.
++    //
++    // For capturers that own their own picker (delegated source list, e.g. the
++    // xdg-desktop-portal PipeWire capturer on Wayland) StartUpdating() opens
++    // that picker dialog.  Doing this once per list (screens + windows) inside
++    // DesktopMediaController would surface two redundant portal dialogs in
++    // addition to the one the video-capture service later opens for the
++    // actually streamed source - see QTBUG-142081.  Skip StartUpdating() in
++    // that case; Update() has already provided the synthetic source the
++    // delegated backend exposes, which is sufficient for selectScreen() /
++    // selectWindow() to forward the correct DesktopMediaID to the capture
++    // pipeline.
+     if (mediaList) {
++        const bool isDelegated = mediaList->IsSourceListDelegated();
+         base::OnceCallback<void()> onComplete = base::BindOnce(
+-                [](DesktopMediaListQtPrivate *observer) {
++                [](DesktopMediaListQtPrivate *observer, bool isDelegated) {
+                     Q_EMIT observer->q_ptr->initialized();
+-                    observer->startUpdating();
++                    if (!isDelegated)
++                        observer->startUpdating();
+                 },
+-                this);
++                this, isDelegated);
+         mediaList->Update(std::move(onComplete));
+     } else {
+         QTimer::singleShot(0, q_ptr, [this]() { Q_EMIT q_ptr->initialized(); });


### PR DESCRIPTION
In current releases Qt shows three screen sharing dialogs at a time (QTBUG-142081) when running as a flatpak and using a pre selected picking (screen vs window). This MR resolves the issue by only letting the wired request pass.

Without the patch, you run into three picker windows, where you don't know which one is the one which really does something:

<img width="1868" height="1233" alt="image" src="https://github.com/user-attachments/assets/6508c4bf-99a8-475d-ad86-beb71161417d" />

The screenshot shows the Qt mini browser example placed in a flatpak.